### PR TITLE
fix: WDT soft reset

### DIFF
--- a/web-logic-analyzer.ino
+++ b/web-logic-analyzer.ino
@@ -603,6 +603,7 @@ extern void IRAM_ATTR collect()
     do
     {
       value = RAW_READ() & MASK;
+      yield();
     } while (value == values[i - 1] && !stopListen);
     times[i] = micros();
     values[i] = value;


### PR DESCRIPTION
Added yield() at loop during capture to not trigger WDT reset over time.

![image](https://github.com/hepter/web-logic-analyzer/assets/31147592/2300cff2-3bca-4c89-98f9-a19acaa3114a)
